### PR TITLE
fix ci

### DIFF
--- a/dvc_gs/tests/cloud.py
+++ b/dvc_gs/tests/cloud.py
@@ -99,4 +99,7 @@ class FakeGCP(GCP):
     def _gc(self):
         from google.cloud.storage import Client
 
-        return Client(client_options={"api_endpoint": self.endpoint_url})
+        return Client(
+            use_auth_w_custom_endpoint=False,
+            client_options={"api_endpoint": self.endpoint_url},
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ tests =
     pytest-xdist==2.4.0
     pytest-mock==3.6.1
     pytest-lazy-fixture==0.6.3
-    pytest-servers[gcs]==0.0.10
+    pytest-servers[gcs]==0.1.4
     flaky==3.7.0
     mock==4.0.3
     wget==3.2


### PR DESCRIPTION
- bump pytest-test servers to 0.1.4 (fixes `moto[server]` dependency issue)
- do not try to authenticate to google services with `FakeGCP`