### PR TITLE
Set `version_aware` from config.

### DIFF
--- a/dvc_gs/__init__.py
+++ b/dvc_gs/__init__.py
@@ -21,6 +21,7 @@ class GSFileSystem(ObjectFileSystem):
 
     def _prepare_credentials(self, **config):
         login_info = {"consistency": None}
+        login_info["version_aware"] = config.get("version_aware", False)
         login_info["project"] = config.get("projectname")
         login_info["token"] = config.get("credentialpath")
         login_info["endpoint_url"] = config.get("endpointurl")


### PR DESCRIPTION
Was causing `dvc import-url --version-aware gs:/verioned-bucket/data` to behave as without `--version-aware`