### PR TITLE
Empty string as default for projectname.

### DIFF
--- a/dvc_gs/__init__.py
+++ b/dvc_gs/__init__.py
@@ -22,7 +22,7 @@ class GSFileSystem(ObjectFileSystem):
     def _prepare_credentials(self, **config):
         login_info = {"consistency": None}
         login_info["version_aware"] = config.get("version_aware", False)
-        login_info["project"] = config.get("projectname")
+        login_info["project"] = config.get("projectname", '')
         login_info["token"] = config.get("credentialpath")
         login_info["endpoint_url"] = config.get("endpointurl")
         login_info["session_kwargs"] = {"trust_env": True}

--- a/dvc_gs/__init__.py
+++ b/dvc_gs/__init__.py
@@ -22,7 +22,9 @@ class GSFileSystem(ObjectFileSystem):
     def _prepare_credentials(self, **config):
         login_info = {"consistency": None}
         login_info["version_aware"] = config.get("version_aware", False)
-        login_info["project"] = config.get("projectname", '')
+        project = config.get("projectname")
+        if project is not None:
+            login_info["project"] = project
         login_info["token"] = config.get("credentialpath")
         login_info["endpoint_url"] = config.get("endpointurl")
         login_info["session_kwargs"] = {"trust_env": True}


### PR DESCRIPTION
Default return of [dict.get()](https://docs.python.org/3.11/library/stdtypes.html?highlight=get#dict.get) is None. This caused issues with gcsfs: `gcsfs/core.py:285: UserWarning: GCS project not set - cannot list or create buckets`. The new default of '' provided functions as intended with gcsfs able to read the correct project name from the gcp key.json file.

Fixes #35 